### PR TITLE
isNorway skal berre vere true om landkoden er 0192 ikkje 9908

### DIFF
--- a/domain/src/main/java/no/difi/meldingsutveksling/domain/ICD.java
+++ b/domain/src/main/java/no/difi/meldingsutveksling/domain/ICD.java
@@ -118,6 +118,6 @@ public enum ICD {
     }
 
     public boolean isNorway() {
-        return this == ICD.NO_ORGNR || this == ICD.NO_ORG;
+        return this == ICD.NO_ORG;
     }
 }


### PR DESCRIPTION
Mogleg denne ikkje hastar, ref diskusjon i standup idag.